### PR TITLE
Save CSVs to configurable data directory

### DIFF
--- a/config.py
+++ b/config.py
@@ -9,3 +9,4 @@ BASE_POS = (BASE_X, BASE_Y)
 TICK_LIMIT = 100
 GIF_NAME = "simulation.gif"
 RECHARGE = 5
+DATA_DIR = "data"

--- a/robot.py
+++ b/robot.py
@@ -12,6 +12,7 @@ from config import (
     MAP_L,
     MAP_H,
     RECHARGE,
+    DATA_DIR,
 )
 
 
@@ -64,8 +65,9 @@ class Robot:
         return True
 
     def save_csv(self) -> None:
-        os.makedirs("data", exist_ok=True)
-        with open(f"data/robot_{self.id}.csv", "w", newline="", encoding="utf-8") as f:
+        os.makedirs(DATA_DIR, exist_ok=True)
+        path = os.path.join(DATA_DIR, f"robot_{self.id}.csv")
+        with open(path, "w", newline="", encoding="utf-8") as f:
             writer = csv.writer(f)
             writer.writerow(["datetime", "temperature", "battery"])
             for dt, temp, bat in self.logs:


### PR DESCRIPTION
## Summary
- add `DATA_DIR` constant in `config.py`
- use the new constant when exporting robot logs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68559e249adc8330a250a3d183a03f6e