### PR TITLE
Add resistor color helper functions

### DIFF
--- a/Resistor Color/resistor_color.c
+++ b/Resistor Color/resistor_color.c
@@ -1,0 +1,19 @@
+#include "resistor_color.h"
+#include <stdint.h>
+uint16_t color_code(resistor_band_t code){
+    return (uint16_t)code;
+}
+
+const resistor_band_t* colors(void){
+    static const resistor_band_t colors[]={BLACK,
+        BROWN,
+        RED,
+        ORANGE,
+        YELLOW,
+        GREEN,
+        BLUE,
+        VIOLET,
+        GREY,
+        WHITE};
+    return colors;
+}

--- a/Resistor Color/resistor_color.h
+++ b/Resistor Color/resistor_color.h
@@ -1,0 +1,18 @@
+#ifndef RESISTOR_COLOR_H
+#define RESISTOR_COLOR_H
+#include <stdint.h>
+typedef enum {
+    BLACK = 0,
+    BROWN = 1,
+    RED = 2,
+    ORANGE = 3,
+    YELLOW = 4,
+    GREEN = 5,
+    BLUE = 6,
+    VIOLET = 7,
+    GREY = 8,
+    WHITE = 9
+} resistor_band_t;
+uint16_t color_code(resistor_band_t code);
+const resistor_band_t* colors(void);
+#endif


### PR DESCRIPTION
## Summary
- add resistor color enum definitions and lookup helpers

## Testing
- `gcc -std=c11 -Wall -Wextra -pedantic -c 'Resistor Color/resistor_color.c'`
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_689716b37c688330901d473ca9bacb9a